### PR TITLE
Fix locale-aware timestamp formatting

### DIFF
--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -4,6 +4,8 @@ import {
   truncateAddress,
   isValidAmount,
   timeUntil,
+  formatDate,
+  formatTime,
   calculatePayout,
   calculateOdds,
   bpsToPercent,
@@ -168,6 +170,20 @@ describe("timeUntil", () => {
     const now = Math.floor(Date.now() / 1000);
     const future = now + 30;
     expect(timeUntil(future)).toBe("30s");
+  });
+});
+
+describe("timestamp formatting", () => {
+  it("formats dates with locale and timezone consistently", () => {
+    expect(formatDate(1772064000, "en-US", { timeZone: "UTC" })).toBe(
+      "Feb 26, 2026, 12:00 AM UTC"
+    );
+  });
+
+  it("formats times with locale and timezone consistently", () => {
+    expect(formatTime(1772064000, "en-US", { timeZone: "UTC" })).toBe(
+      "12:00 AM UTC"
+    );
   });
 });
 

--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   truncateAddress,
   isValidAmount,
   timeUntil,
+  normalizeUnixTimestamp,
   formatDate,
   formatTime,
   calculatePayout,
@@ -174,8 +175,18 @@ describe("timeUntil", () => {
 });
 
 describe("timestamp formatting", () => {
+  it("normalizes millisecond timestamps to Unix seconds", () => {
+    expect(normalizeUnixTimestamp(1772064000000)).toBe(1772064000);
+  });
+
   it("formats dates with locale and timezone consistently", () => {
     expect(formatDate(1772064000, "en-US", { timeZone: "UTC" })).toBe(
+      "Feb 26, 2026, 12:00 AM UTC"
+    );
+  });
+
+  it("formats millisecond timestamps without drifting into the future", () => {
+    expect(formatDate(1772064000000, "en-US", { timeZone: "UTC" })).toBe(
       "Feb 26, 2026, 12:00 AM UTC"
     );
   });

--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useWallet } from "@/hooks/useWallet";
 import { useToken } from "@/hooks/useToken";
 import { pollMarketEvents } from "@/services/events";
 import { getXlmBalance } from "@/services/soroban";
-import { displayXLM, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
+import { displayXLM, formatXLM, formatTime, calculatePayout, truncateAddress } from "@/utils/helpers";
 import {
   WIN_POINTS,
   LOSE_POINTS,
@@ -319,7 +319,7 @@ export default function MarketDetailPage({
                       </span>
                     </div>
                     <span className="text-xs text-slate-600 shrink-0">
-                      {new Date(evt.timestamp * 1000).toLocaleTimeString()}
+                      {formatTime(evt.timestamp)}
                     </span>
                   </div>
                 ))}

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -2,6 +2,7 @@ import { rpc, scValToNative, xdr } from "@stellar/stellar-sdk";
 import { MARKET_CONTRACT_ID } from "@/config/network";
 import { getSorobanServer } from "@/services/soroban";
 import type { MarketEvent } from "@/types";
+import { normalizeUnixTimestamp } from "@/utils/helpers";
 
 // ── Event type names emitted by the PredictionMarket contract ─────────────────
 
@@ -32,7 +33,9 @@ function parseEventResponse(
     if (!isKnownEventType(eventName)) return null;
 
     const data = scValToNative(event.value);
-    const timestamp = new Date(event.ledgerClosedAt).getTime();
+    const timestamp = normalizeUnixTimestamp(
+      new Date(event.ledgerClosedAt).getTime()
+    );
 
     switch (eventName) {
       case "bet_placed":

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -77,11 +77,17 @@ export function timeUntil(timestamp: number): string {
 /**
  * Format a Unix timestamp to a locale-aware date string.
  */
+export function normalizeUnixTimestamp(timestamp: number): number {
+  return timestamp > 9_999_999_999 ? Math.floor(timestamp / 1000) : timestamp;
+}
+
 export function formatDate(
   timestamp: number,
   locale?: string | string[],
   options: Intl.DateTimeFormatOptions = {}
 ): string {
+  const unixTimestamp = normalizeUnixTimestamp(timestamp);
+
   return new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "short",
@@ -90,7 +96,7 @@ export function formatDate(
     minute: "2-digit",
     timeZoneName: "short",
     ...options,
-  }).format(new Date(timestamp * 1000));
+  }).format(new Date(unixTimestamp * 1000));
 }
 
 /**
@@ -101,12 +107,14 @@ export function formatTime(
   locale?: string | string[],
   options: Intl.DateTimeFormatOptions = {}
 ): string {
+  const unixTimestamp = normalizeUnixTimestamp(timestamp);
+
   return new Intl.DateTimeFormat(locale, {
     hour: "2-digit",
     minute: "2-digit",
     timeZoneName: "short",
     ...options,
-  }).format(new Date(timestamp * 1000));
+  }).format(new Date(unixTimestamp * 1000));
 }
 
 /**

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -77,14 +77,36 @@ export function timeUntil(timestamp: number): string {
 /**
  * Format a Unix timestamp to a locale-aware date string.
  */
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
+export function formatDate(
+  timestamp: number,
+  locale?: string | string[],
+  options: Intl.DateTimeFormatOptions = {}
+): string {
+  return new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-  });
+    timeZoneName: "short",
+    ...options,
+  }).format(new Date(timestamp * 1000));
+}
+
+/**
+ * Format a Unix timestamp to a locale-aware time string.
+ */
+export function formatTime(
+  timestamp: number,
+  locale?: string | string[],
+  options: Intl.DateTimeFormatOptions = {}
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+    ...options,
+  }).format(new Date(timestamp * 1000));
 }
 
 /**


### PR DESCRIPTION
## Summary
- switch Unix timestamp formatting to `Intl.DateTimeFormat` using the user's locale by default
- include short timezone names for date/time displays so timestamps are consistent across views
- reuse the shared time formatter in the market activity feed instead of calling `toLocaleTimeString()` directly
- add deterministic UTC coverage for the date/time helpers

Fixes #27

## Validation
- node Intl.DateTimeFormat check for the UTC date and time fixture
- `npx.cmd --yes -p typescript@5.7.3 tsc --noEmit --target ES2020 --lib ES2020,DOM --moduleResolution node frontend/src/utils/helpers.ts`
- `git diff --check`

Note: I could not run the full Vitest suite from a clean clone because `frontend/package.json` is absent even though `frontend/package-lock.json` exists. A temporary `npx` Vitest attempt failed while loading `vitest.config.ts` because `vitest/config` is not resolvable from the repo without installed project dependencies.
