### PR TITLE
fix: use user-local timestamp formatting

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "stellarpulse-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@creit.tech/stellar-wallets-kit": "^1.2.0",
+    "@stellar/stellar-sdk": "^14.5.0",
+    "buffer": "^6.0.3",
+    "next": "^14.2.29",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@types/node": "^22.13.5",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.1",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/frontend/src/__tests__/events.test.ts
+++ b/frontend/src/__tests__/events.test.ts
@@ -9,4 +9,8 @@ describe("event timestamp parsing", () => {
       Date.UTC(2026, 1, 26, 2, 5, 30) / 1000
     );
   });
+
+  it("preserves numeric Unix seconds instead of treating them as milliseconds", () => {
+    expect(ledgerClosedAtToUnixSeconds(1771985130)).toBe(1771985130);
+  });
 });

--- a/frontend/src/__tests__/events.test.ts
+++ b/frontend/src/__tests__/events.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { ledgerClosedAtToUnixSeconds } from "@/services/events";
+
+describe("event timestamp parsing", () => {
+  it("normalizes ledgerClosedAt to Unix seconds for UI formatters", () => {
+    const closedAt = "2026-02-26T02:05:30.000Z";
+
+    expect(ledgerClosedAtToUnixSeconds(closedAt)).toBe(
+      Date.UTC(2026, 1, 26, 2, 5, 30) / 1000
+    );
+  });
+});

--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -4,6 +4,8 @@ import {
   truncateAddress,
   isValidAmount,
   timeUntil,
+  formatDate,
+  formatTime,
   calculatePayout,
   calculateOdds,
   bpsToPercent,
@@ -172,6 +174,45 @@ describe("timeUntil", () => {
 });
 
 // ── calculatePayout ───────────────────────────────────────────────────────────
+
+describe("timestamp formatting", () => {
+  const timestamp = Date.UTC(2026, 1, 26, 2, 5) / 1000;
+
+  it("formats date/time with the provided locale and time zone", () => {
+    const options = { timeZone: "UTC" };
+
+    expect(formatDate(timestamp, "en-US", options)).toBe(
+      new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "UTC",
+      }).format(new Date(timestamp * 1000))
+    );
+  });
+
+  it("does not hard-code a single locale", () => {
+    const options = { timeZone: "UTC" };
+
+    expect(formatDate(timestamp, "de-DE", options)).not.toBe(
+      formatDate(timestamp, "en-US", options)
+    );
+  });
+
+  it("formats compact local times through the shared helper", () => {
+    const options = { timeZone: "UTC" };
+
+    expect(formatTime(timestamp, "en-US", options)).toBe(
+      new Intl.DateTimeFormat("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZone: "UTC",
+      }).format(new Date(timestamp * 1000))
+    );
+  });
+});
 
 describe("calculatePayout", () => {
   it("calculates correct payout for sole winner (100% of winning side)", () => {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -13,6 +13,7 @@ const inter = Inter({
 
 const poppins = Poppins({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-heading",
   display: "swap",
 });

--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -7,7 +7,13 @@ import { useWallet } from "@/hooks/useWallet";
 import { useToken } from "@/hooks/useToken";
 import { pollMarketEvents } from "@/services/events";
 import { getXlmBalance } from "@/services/soroban";
-import { displayXLM, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
+import {
+  displayXLM,
+  formatTime,
+  formatXLM,
+  calculatePayout,
+  truncateAddress,
+} from "@/utils/helpers";
 import {
   WIN_POINTS,
   LOSE_POINTS,
@@ -319,7 +325,7 @@ export default function MarketDetailPage({
                       </span>
                     </div>
                     <span className="text-xs text-slate-600 shrink-0">
-                      {new Date(evt.timestamp * 1000).toLocaleTimeString()}
+                      {formatTime(evt.timestamp)}
                     </span>
                   </div>
                 ))}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -42,10 +42,10 @@ export default function Navbar() {
           <Link
             href="/"
             className="flex items-center gap-3 select-none transition-transform duration-200 hover:scale-105"
-            aria-label="Stellar Pulse home"
+            aria-label="StellarPulse home"
           >
             <span className="text-xl font-bold text-white">SP</span>
-            <span className="hidden sm:inline-block text-lg font-semibold text-white text-gradient">Stellar Pulse</span>
+            <span className="hidden sm:inline-block text-lg font-semibold text-white text-gradient">StellarPulse</span>
           </Link>
 
           {/* Desktop nav links */}

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -22,6 +22,16 @@ function isKnownEventType(s: string): s is ContractEventType {
 export function ledgerClosedAtToUnixSeconds(
   ledgerClosedAt: string | number | Date
 ): number {
+  if (typeof ledgerClosedAt === "number") {
+    // Soroban timestamps are Unix seconds; tolerate millisecond values from
+    // callers that already normalized the API response to a number.
+    return Math.floor(
+      ledgerClosedAt >= 1_000_000_000_000
+        ? ledgerClosedAt / 1000
+        : ledgerClosedAt
+    );
+  }
+
   return Math.floor(new Date(ledgerClosedAt).getTime() / 1000);
 }
 

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -19,6 +19,12 @@ function isKnownEventType(s: string): s is ContractEventType {
   return (EVENT_TYPES as readonly string[]).includes(s);
 }
 
+export function ledgerClosedAtToUnixSeconds(
+  ledgerClosedAt: string | number | Date
+): number {
+  return Math.floor(new Date(ledgerClosedAt).getTime() / 1000);
+}
+
 // ── Parse a single event response into MarketEvent ────────────────────────────
 
 function parseEventResponse(
@@ -32,7 +38,7 @@ function parseEventResponse(
     if (!isKnownEventType(eventName)) return null;
 
     const data = scValToNative(event.value);
-    const timestamp = new Date(event.ledgerClosedAt).getTime();
+    const timestamp = ledgerClosedAtToUnixSeconds(event.ledgerClosedAt);
 
     switch (eventName) {
       case "bet_placed":

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -75,16 +75,48 @@ export function timeUntil(timestamp: number): string {
 }
 
 /**
- * Format a Unix timestamp to a locale-aware date string.
+ * Shared date/time options keep timestamp display consistent while letting the
+ * browser choose the user's locale and time zone by default.
  */
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+const TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+/**
+ * Format a Unix timestamp to the user's locale and time zone.
+ */
+export function formatDate(
+  timestamp: number,
+  locale?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...DATE_TIME_OPTIONS,
+    ...options,
+  }).format(new Date(timestamp * 1000));
+}
+
+/**
+ * Format a Unix timestamp to a compact user-local time.
+ */
+export function formatTime(
+  timestamp: number,
+  locale?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...TIME_OPTIONS,
+    ...options,
+  }).format(new Date(timestamp * 1000));
 }
 
 /**


### PR DESCRIPTION
## Summary
- format Unix timestamps through shared Intl.DateTimeFormat helpers that default to the user's locale and time zone
- replace the activity feed's direct toLocaleTimeString call with the shared compact time formatter
- restore the missing frontend package.json so the documented npm test/build workflow works
- fix two existing verification blockers: the navbar brand text expected by tests and the required Poppins font weights for next build

## Why
Issue #27 asks for timestamps to be normalized to the user locale with consistent formatting. This keeps formatting centralized without forcing UTC, so users see dates/times in their own browser locale and time zone.

## Verification
- npm test
- npm run build

Fixes #27