### PR TITLE
fix: localize and normalize timestamps across leaderboard views

### DIFF
--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   truncateAddress,
   isValidAmount,
   timeUntil,
+  formatDate,
   calculatePayout,
   calculateOdds,
   bpsToPercent,
@@ -168,6 +169,31 @@ describe("timeUntil", () => {
     const now = Math.floor(Date.now() / 1000);
     const future = now + 30;
     expect(timeUntil(future)).toBe("30s");
+  });
+});
+
+// ── formatDate ────────────────────────────────────────────────────────────────
+
+describe("formatDate", () => {
+  const timestampMs = Date.UTC(2026, 1, 26, 15, 4);
+  const timestampSeconds = timestampMs / 1000;
+
+  it("normalizes Unix seconds and milliseconds to the same instant", () => {
+    expect(formatDate(timestampSeconds, "en-US", "UTC")).toBe(
+      formatDate(timestampMs, "en-US", "UTC")
+    );
+  });
+
+  it("formats a complete date and time consistently", () => {
+    expect(formatDate(timestampMs, "en-US", "UTC")).toBe(
+      "Feb 26, 2026, 03:04 PM"
+    );
+  });
+
+  it("respects the requested locale", () => {
+    expect(formatDate(timestampMs, "de-DE", "UTC")).toBe(
+      "26. Feb. 2026, 15:04"
+    );
   });
 });
 

--- a/frontend/src/__tests__/useLeaderboard.test.tsx
+++ b/frontend/src/__tests__/useLeaderboard.test.tsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  getTopPlayers: vi.fn(),
+  getStats: vi.fn(),
+  getMarkets: vi.fn(),
+  getMarketBettors: vi.fn(),
+  getDisplayName: vi.fn(),
+  cacheSet: vi.fn(),
+}));
+
+vi.mock("@/services/leaderboard", () => ({
+  getTopPlayers: mocks.getTopPlayers,
+  getStats: mocks.getStats,
+}));
+
+vi.mock("@/services/market", () => ({
+  getMarkets: mocks.getMarkets,
+  getMarketBettors: mocks.getMarketBettors,
+}));
+
+vi.mock("@/services/referral", () => ({
+  getDisplayName: mocks.getDisplayName,
+}));
+
+vi.mock("@/services/cache", () => ({
+  getStale: () => null,
+  set: mocks.cacheSet,
+}));
+
+vi.mock("@/hooks/useVisiblePoll", () => ({
+  useVisiblePoll: vi.fn(),
+}));
+
+import { useLeaderboard } from "@/hooks/useLeaderboard";
+
+describe("useLeaderboard lastUpdated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getMarkets.mockResolvedValue([]);
+  });
+
+  it("records a millisecond timestamp after a successful refresh", async () => {
+    const refreshedAt = 1_800_000_000_123;
+    vi.spyOn(Date, "now").mockReturnValue(refreshedAt);
+    mocks.getTopPlayers.mockResolvedValue([
+      {
+        address: "GALICE",
+        displayName: "Alice",
+        points: 100,
+        totalBets: 4,
+        wonBets: 3,
+        lostBets: 1,
+        winRate: 75,
+      },
+    ]);
+
+    const { result } = renderHook(() => useLeaderboard("top_predictors"));
+
+    expect(result.current.lastUpdated).toBeNull();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.lastUpdated).toBe(refreshedAt);
+  });
+
+  it("does not claim a refresh time when loading fails", async () => {
+    mocks.getTopPlayers.mockRejectedValue(new Error("RPC unavailable"));
+
+    const { result } = renderHook(() => useLeaderboard("top_predictors"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("RPC unavailable");
+    expect(result.current.lastUpdated).toBeNull();
+  });
+});

--- a/frontend/src/app/leaderboard/page.tsx
+++ b/frontend/src/app/leaderboard/page.tsx
@@ -8,11 +8,12 @@ import LeaderboardTable from "@/components/leaderboard/LeaderboardTable";
 import Skeleton from "@/components/ui/Skeleton";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorBoundary from "@/components/ui/ErrorBoundary";
+import { formatDate } from "@/utils/helpers";
 import { FiAward } from "react-icons/fi";
 
 export default function LeaderboardPage() {
   const [tab, setTab] = useState<LeaderboardTab>("top_predictors");
-  const { data: players, loading, error } = useLeaderboard(tab);
+  const { data: players, loading, error, lastUpdated } = useLeaderboard(tab);
   const { publicKey } = useWallet();
 
   return (
@@ -31,6 +32,11 @@ export default function LeaderboardPage() {
         <p className="text-slate-400">
           Rankings update in real-time from onchain data.
         </p>
+        {lastUpdated !== null && (
+          <p className="mt-1 text-xs text-slate-500">
+            Last updated: {formatDate(lastUpdated)}
+          </p>
+        )}
       </div>
 
       {/* Tabs */}
@@ -77,4 +83,3 @@ export default function LeaderboardPage() {
     </div>
   );
 }
-

--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -7,7 +7,13 @@ import { useWallet } from "@/hooks/useWallet";
 import { useToken } from "@/hooks/useToken";
 import { pollMarketEvents } from "@/services/events";
 import { getXlmBalance } from "@/services/soroban";
-import { displayXLM, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
+import {
+  displayXLM,
+  formatXLM,
+  formatDate,
+  calculatePayout,
+  truncateAddress,
+} from "@/utils/helpers";
 import {
   WIN_POINTS,
   LOSE_POINTS,
@@ -319,7 +325,7 @@ export default function MarketDetailPage({
                       </span>
                     </div>
                     <span className="text-xs text-slate-600 shrink-0">
-                      {new Date(evt.timestamp * 1000).toLocaleTimeString()}
+                      {formatDate(evt.timestamp)}
                     </span>
                   </div>
                 ))}

--- a/frontend/src/hooks/useLeaderboard.ts
+++ b/frontend/src/hooks/useLeaderboard.ts
@@ -22,6 +22,7 @@ interface UseLeaderboardResult {
   data: PlayerStats[];
   loading: boolean;
   error: string | null;
+  lastUpdated: number | null;
   refetch: () => void;
 }
 
@@ -107,6 +108,7 @@ export function useLeaderboard(
   const [data, setData] = useState<PlayerStats[]>([]);
   const [loading, setLoading] = useState(!seeded.current);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const mountedRef = useRef(true);
   const initialLoadDone = useRef(false);
 
@@ -153,6 +155,7 @@ export function useLeaderboard(
       // Persist assembled leaderboard for instant stale-seed next time
       cache.set(LB_CACHE_KEY, players, 60_000);
       setAllPlayers(players);
+      setLastUpdated(Date.now());
     } catch (err) {
       if (!mountedRef.current) return;
       setError(
@@ -189,5 +192,5 @@ export function useLeaderboard(
     fetchData();
   }, [fetchData]);
 
-  return { data, loading, error, refetch };
+  return { data, loading, error, lastUpdated, refetch };
 }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -74,17 +74,32 @@ export function timeUntil(timestamp: number): string {
   return `${seconds}s`;
 }
 
+/** Values below this threshold are Unix seconds; larger values are milliseconds. */
+const MILLISECOND_TIMESTAMP_THRESHOLD = 100_000_000_000;
+
 /**
- * Format a Unix timestamp to a locale-aware date string.
+ * Format a seconds- or milliseconds-based Unix timestamp in the user's locale.
+ * Supplying a locale and time zone is useful for deterministic rendering/tests;
+ * browser defaults are used in the application.
  */
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
+export function formatDate(
+  timestamp: number,
+  locale?: string,
+  timeZone?: string
+): string {
+  const timestampMs =
+    Math.abs(timestamp) < MILLISECOND_TIMESTAMP_THRESHOLD
+      ? timestamp * 1000
+      : timestamp;
+
+  return new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-  });
+    ...(timeZone ? { timeZone } : {}),
+  }).format(new Date(timestampMs));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Normalize Unix-second and JavaScript-millisecond timestamps through one formatter.
- Use the viewer's locale and time zone instead of hard-coding `en-US` or UTC.
- Record and display the leaderboard's successful refresh time.
- Reuse the same formatter in the market activity feed, fixing the existing millisecond value being multiplied by 1,000 again.
- Add deterministic locale/unit tests and hook tests for successful and failed refreshes.

## Root cause

The existing helper assumed every value was Unix seconds and hard-coded `en-US`. Market events are stored as milliseconds, but the activity view multiplied them by 1,000 again. The leaderboard also did not expose or render a refresh timestamp, so there was no consistent timestamp display to localize.

## User impact

Leaderboard and activity timestamps now represent the correct instant and follow the user's browser locale/time zone. Failed refreshes do not display a misleading new timestamp.

## Validation

- `npx vitest run src/__tests__/helpers.test.ts src/__tests__/useLeaderboard.test.tsx src/__tests__/components/LeaderboardTable.test.tsx` — 64/64 passed.
- Full suite — 156/158 passed. The two remaining failures are pre-existing Navbar assertions that look for `StellarPulse` while the component renders `Stellar Pulse`.
- `tsc --noEmit` reports only the pre-existing `src/app/layout.tsx` Google Font configuration error (`weight` is required).
- `git diff --check` passes.

The repository currently omits `frontend/package.json`; local validation used a temporary manifest reconstructed from the committed `package-lock.json`. The manifest is not part of this PR.

Closes #27
