### PR TITLE
fix(timestamps): localize events and reject malformed ledger dates

### DIFF
--- a/frontend/src/__tests__/events.test.ts
+++ b/frontend/src/__tests__/events.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getLatestLedger: vi.fn(),
+  getEvents: vi.fn(),
+}));
+
+vi.mock("@stellar/stellar-sdk", async () => {
+  const actual = await vi.importActual<typeof import("@stellar/stellar-sdk")>(
+    "@stellar/stellar-sdk"
+  );
+  return { ...actual, scValToNative: (value: unknown) => value };
+});
+
+vi.mock("@/services/soroban", () => ({
+  getSorobanServer: () => ({
+    getLatestLedger: mocks.getLatestLedger,
+    getEvents: mocks.getEvents,
+  }),
+}));
+
+import {
+  ledgerClosedAtToUnixSeconds,
+  pollMarketEvents,
+} from "@/services/events";
+
+describe("ledgerClosedAtToUnixSeconds", () => {
+  const expected = Date.UTC(2026, 1, 26, 15, 4) / 1000;
+
+  it.each([
+    ["ISO string", "2026-02-26T15:04:00.000Z"],
+    ["numeric milliseconds", Date.UTC(2026, 1, 26, 15, 4)],
+    ["Date", new Date("2026-02-26T15:04:00.000Z")],
+  ])("accepts a valid %s", (_label, value) => {
+    expect(ledgerClosedAtToUnixSeconds(value)).toBe(expected);
+  });
+
+  it.each([
+    ["invalid string", "not-a-date"],
+    ["missing value", undefined],
+    ["NaN", Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY],
+    ["negative infinity", Number.NEGATIVE_INFINITY],
+  ])("throws RangeError for %s", (_label, value) => {
+    expect(() =>
+      ledgerClosedAtToUnixSeconds(value as unknown as string)
+    ).toThrow(new RangeError("Invalid ledger close timestamp"));
+  });
+});
+
+describe("pollMarketEvents", () => {
+  it("discards an event with malformed ledgerClosedAt", async () => {
+    const malformedEvent = {
+      topic: ["market_cancelled", 7],
+      value: {},
+      ledgerClosedAt: "not-a-date",
+      txHash: "malformed-event",
+    };
+
+    mocks.getLatestLedger.mockResolvedValue({ sequence: 100 });
+    mocks.getEvents.mockResolvedValue({ events: [malformedEvent] });
+
+    await expect(pollMarketEvents()).resolves.toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -3,12 +3,30 @@ import {
   formatXLM,
   truncateAddress,
   isValidAmount,
+  formatDate,
+  formatTime,
   timeUntil,
   calculatePayout,
   calculateOdds,
   bpsToPercent,
   explorerUrl,
 } from "@/utils/helpers";
+
+describe("localized timestamp formatters", () => {
+  const timestamp = Date.UTC(2026, 2, 1, 1, 30) / 1000;
+
+  it.each([
+    ["en-US", "UTC", "Mar 1, 2026, 01:30 AM", "01:30 AM"],
+    ["en-US", "America/New_York", "Feb 28, 2026, 08:30 PM", "08:30 PM"],
+    ["en-US", "Asia/Ho_Chi_Minh", "Mar 1, 2026, 08:30 AM", "08:30 AM"],
+    ["vi-VN", "UTC", "01:30 1 thg 3, 2026", "01:30"],
+    ["vi-VN", "America/New_York", "20:30 28 thg 2, 2026", "20:30"],
+    ["vi-VN", "Asia/Ho_Chi_Minh", "08:30 1 thg 3, 2026", "08:30"],
+  ])("formats %s in %s independently of the test machine", (locale, timeZone, date, time) => {
+    expect(formatDate(timestamp, locale, timeZone)).toBe(date);
+    expect(formatTime(timestamp, locale, timeZone)).toBe(time);
+  });
+});
 
 // ── formatXLM ─────────────────────────────────────────────────────────────────
 

--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useWallet } from "@/hooks/useWallet";
 import { useToken } from "@/hooks/useToken";
 import { pollMarketEvents } from "@/services/events";
 import { getXlmBalance } from "@/services/soroban";
-import { displayXLM, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
+import { displayXLM, formatTime, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
 import {
   WIN_POINTS,
   LOSE_POINTS,
@@ -319,7 +319,7 @@ export default function MarketDetailPage({
                       </span>
                     </div>
                     <span className="text-xs text-slate-600 shrink-0">
-                      {new Date(evt.timestamp * 1000).toLocaleTimeString()}
+                      {formatTime(evt.timestamp)}
                     </span>
                   </div>
                 ))}

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -19,6 +19,22 @@ function isKnownEventType(s: string): s is ContractEventType {
   return (EVENT_TYPES as readonly string[]).includes(s);
 }
 
+/** Convert the ledger close time to the app's Unix-seconds timestamp contract. */
+export function ledgerClosedAtToUnixSeconds(
+  ledgerClosedAt: string | number | Date
+): number {
+  const timestampMs =
+    ledgerClosedAt instanceof Date
+      ? ledgerClosedAt.getTime()
+      : new Date(ledgerClosedAt).getTime();
+
+  if (!Number.isFinite(timestampMs)) {
+    throw new RangeError("Invalid ledger close timestamp");
+  }
+
+  return Math.floor(timestampMs / 1000);
+}
+
 // ── Parse a single event response into MarketEvent ────────────────────────────
 
 function parseEventResponse(
@@ -32,7 +48,7 @@ function parseEventResponse(
     if (!isKnownEventType(eventName)) return null;
 
     const data = scValToNative(event.value);
-    const timestamp = new Date(event.ledgerClosedAt).getTime();
+    const timestamp = ledgerClosedAtToUnixSeconds(event.ledgerClosedAt);
 
     switch (eventName) {
       case "bet_placed":

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -129,6 +129,7 @@ export interface MarketEvent {
   user: string;
   marketId: number;
   amount?: number;
+  /** Unix timestamp in seconds. */
   timestamp: number;
   txHash: string;
 }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -74,17 +74,41 @@ export function timeUntil(timestamp: number): string {
   return `${seconds}s`;
 }
 
-/**
- * Format a Unix timestamp to a locale-aware date string.
- */
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+const TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+/** Format Unix seconds in the viewer's locale and time zone by default. */
+export function formatDate(
+  timestamp: number,
+  locale?: string | string[],
+  timeZone?: string
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...DATE_TIME_OPTIONS,
+    ...(timeZone ? { timeZone } : {}),
+  }).format(new Date(timestamp * 1000));
+}
+
+/** Format Unix seconds as a localized time of day. */
+export function formatTime(
+  timestamp: number,
+  locale?: string | string[],
+  timeZone?: string
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...TIME_OPTIONS,
+    ...(timeZone ? { timeZone } : {}),
+  }).format(new Date(timestamp * 1000));
 }
 
 /**


### PR DESCRIPTION
## Summary

- format Unix-second timestamps through shared locale-aware date/time helpers
- normalize Soroban `ledgerClosedAt` values to Unix seconds at the event boundary
- reject invalid, missing, `NaN`, and infinite ledger timestamps with a clear `RangeError`
- verify the full parser path drops malformed events before they can enter UI state

## Unique correctness advantage

PR #36 adds `ledgerClosedAtToUnixSeconds`, but it returns `NaN` for malformed or non-finite inputs. That bypasses the parser's existing catch path and allows an event containing `timestamp: NaN` into the returned event list.

This patch validates the converted millisecond value with `Number.isFinite` and throws `RangeError("Invalid ledger close timestamp")`. The existing parser catches that error and discards the malformed event.

No seconds-versus-milliseconds heuristic is introduced: event inputs are normalized once at the service boundary, and application formatters retain a Unix-seconds contract.

## Regression evidence

With the finite-value guard temporarily removed:

- event regression suite: **3 passed, 6 failed**
- invalid string, missing value, `NaN`, `Infinity`, and `-Infinity` did not throw
- the parser-level test returned an event containing `timestamp: NaN` instead of an empty result

With the guard present:

- focused timestamp/event tests: **64/64 passed**

## Additional validation

- full test suite: all issue-related tests pass; 3 unrelated failures remain and reproduce on unmodified `main`
  - 2 stale Navbar assertions expect `StellarPulse` while the component renders `Stellar Pulse`
  - 1 leaderboard assertion expects an en-US thousands separator while this environment renders the locale separator
- TypeScript check: blocked only by the pre-existing missing Poppins `weight` in `src/app/layout.tsx`
- production build: blocked by the same pre-existing Poppins configuration
- lint: skipped because the repository has no ESLint configuration and `next lint` requires interactive setup
- `git diff --check`: passed

Closes #27
