### PR TITLE
fix: normalize leaderboard/activity timestamps to unix-seconds and viewer locale

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "stellarpulse-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@creit.tech/stellar-wallets-kit": "^1.2.0",
+    "@stellar/stellar-sdk": "^14.5.0",
+    "buffer": "^6.0.3",
+    "next": "^14.2.29",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@types/node": "^22.13.5",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.1",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/frontend/src/__tests__/events.test.ts
+++ b/frontend/src/__tests__/events.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { ledgerClosedAtToUnixSeconds } from "@/services/events";
+
+describe("ledgerClosedAtToUnixSeconds", () => {
+  it("converts an ISO string from Soroban RPC to Unix seconds", () => {
+    expect(ledgerClosedAtToUnixSeconds("2026-01-15T10:30:00Z")).toBe(
+      1768473000
+    );
+  });
+
+  it("floors sub-second precision instead of rounding", () => {
+    expect(ledgerClosedAtToUnixSeconds("2026-01-15T10:30:00.999Z")).toBe(
+      1768473000
+    );
+  });
+
+  it("is idempotent with a Date instance", () => {
+    const iso = "2026-01-15T10:30:00Z";
+    expect(ledgerClosedAtToUnixSeconds(new Date(iso))).toBe(
+      ledgerClosedAtToUnixSeconds(iso)
+    );
+  });
+});

--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -8,6 +8,8 @@ import {
   calculateOdds,
   bpsToPercent,
   explorerUrl,
+  formatDate,
+  formatTime,
 } from "@/utils/helpers";
 
 // ── formatXLM ─────────────────────────────────────────────────────────────────
@@ -274,5 +276,50 @@ describe("explorerUrl", () => {
     expect(explorerUrl("contract", "CDEF456")).toBe(
       "https://stellar.expert/explorer/public/contract/CDEF456"
     );
+  });
+});
+
+// formatDate / formatTime
+
+const FIXED_SECONDS = 1768473000; 
+const FIXED_MS = FIXED_SECONDS * 1000;
+
+describe("formatDate", () => {
+  it("renders the same instant the same way whether given seconds or milliseconds", () => {
+    // multiplied by 1000 again produced a wildly wrong future date.
+    expect(formatDate(FIXED_SECONDS, "en-US", "UTC")).toBe(
+      formatDate(FIXED_MS, "en-US", "UTC")
+    );
+  });
+
+  it("respects an explicit locale", () => {
+    const enUS = formatDate(FIXED_SECONDS, "en-US", "UTC");
+    const deDE = formatDate(FIXED_SECONDS, "de-DE", "UTC");
+    expect(enUS).not.toBe(deDE);
+  });
+
+  it("respects an explicit time zone and labels it", () => {
+    const utc = formatDate(FIXED_SECONDS, "en-US", "UTC");
+    const tokyo = formatDate(FIXED_SECONDS, "en-US", "Asia/Tokyo");
+    expect(utc).not.toBe(tokyo);
+    // A short zone label should be present so the instant is unambiguous.
+    expect(tokyo).toMatch(/GMT|JST|UTC/);
+  });
+
+  it("returns a stable invalid-date marker for NaN input", () => {
+    expect(formatDate(NaN)).toBe("Invalid date");
+  });
+});
+
+describe("formatTime", () => {
+  it("is unit-tolerant like formatDate", () => {
+    expect(formatTime(FIXED_SECONDS, "en-US", "UTC")).toBe(
+      formatTime(FIXED_MS, "en-US", "UTC")
+    );
+  });
+
+  it("omits the date portion", () => {
+    const time = formatTime(FIXED_SECONDS, "en-US", "UTC");
+    expect(time).not.toMatch(/2026/);
   });
 });

--- a/frontend/src/__tests__/useLeaderboard.test.tsx
+++ b/frontend/src/__tests__/useLeaderboard.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useLeaderboard } from "@/hooks/useLeaderboard";
+
+const mockGetTopPlayers = vi.fn();
+
+vi.mock("@/services/leaderboard", () => ({
+  getTopPlayers: (...args: unknown[]) => mockGetTopPlayers(...args),
+  getStats: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/services/market", () => ({
+  getMarkets: vi.fn().mockResolvedValue([]),
+  getMarketBettors: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/services/referral", () => ({
+  getDisplayName: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("@/services/cache", () => ({
+  get: vi.fn(() => null),
+  getStale: vi.fn(() => null),
+  set: vi.fn(),
+  invalidate: vi.fn(),
+  invalidateAll: vi.fn(),
+}));
+
+vi.mock("@/hooks/useVisiblePoll", () => ({
+  useVisiblePoll: vi.fn(),
+}));
+
+beforeEach(() => {
+  mockGetTopPlayers.mockReset();
+});
+
+describe("useLeaderboard - lastUpdated", () => {
+  it("stays null until the first fetch resolves", async () => {
+    mockGetTopPlayers.mockResolvedValue([]);
+    const { result } = renderHook(() => useLeaderboard("top_predictors"));
+
+    expect(result.current.lastUpdated).toBeNull();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.lastUpdated).not.toBeNull();
+  });
+
+  it("does not update lastUpdated when a refresh fails", async () => {
+    mockGetTopPlayers.mockResolvedValueOnce([]);
+    const { result } = renderHook(() => useLeaderboard("top_predictors"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const firstStamp = result.current.lastUpdated;
+    expect(firstStamp).not.toBeNull();
+
+    mockGetTopPlayers.mockRejectedValueOnce(new Error("RPC unavailable"));
+    result.current.refetch();
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    // A failed refresh must not overwrite lastUpdated with a fresh-looking
+    expect(result.current.lastUpdated).toBe(firstStamp);
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,6 +14,7 @@ const inter = Inter({
 const poppins = Poppins({
   subsets: ["latin"],
   variable: "--font-heading",
+  weight: ["400", "500", "600", "700", "800"],
   display: "swap",
 });
 

--- a/frontend/src/app/leaderboard/page.tsx
+++ b/frontend/src/app/leaderboard/page.tsx
@@ -8,11 +8,12 @@ import LeaderboardTable from "@/components/leaderboard/LeaderboardTable";
 import Skeleton from "@/components/ui/Skeleton";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorBoundary from "@/components/ui/ErrorBoundary";
+import { formatDate } from "@/utils/helpers";
 import { FiAward } from "react-icons/fi";
 
 export default function LeaderboardPage() {
   const [tab, setTab] = useState<LeaderboardTab>("top_predictors");
-  const { data: players, loading, error } = useLeaderboard(tab);
+  const { data: players, loading, error, lastUpdated } = useLeaderboard(tab);
   const { publicKey } = useWallet();
 
   return (
@@ -31,6 +32,11 @@ export default function LeaderboardPage() {
         <p className="text-slate-400">
           Rankings update in real-time from onchain data.
         </p>
+        {lastUpdated !== null && (
+          <p className="mt-1 text-xs text-slate-500">
+            Last updated: {formatDate(lastUpdated)}
+          </p>
+        )}
       </div>
 
       {/* Tabs */}

--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -7,7 +7,13 @@ import { useWallet } from "@/hooks/useWallet";
 import { useToken } from "@/hooks/useToken";
 import { pollMarketEvents } from "@/services/events";
 import { getXlmBalance } from "@/services/soroban";
-import { displayXLM, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
+import {
+  displayXLM,
+  formatXLM,
+  formatTime,
+  calculatePayout,
+  truncateAddress,
+} from "@/utils/helpers";
 import {
   WIN_POINTS,
   LOSE_POINTS,
@@ -319,7 +325,7 @@ export default function MarketDetailPage({
                       </span>
                     </div>
                     <span className="text-xs text-slate-600 shrink-0">
-                      {new Date(evt.timestamp * 1000).toLocaleTimeString()}
+                      {formatTime(evt.timestamp)}
                     </span>
                   </div>
                 ))}

--- a/frontend/src/hooks/useLeaderboard.ts
+++ b/frontend/src/hooks/useLeaderboard.ts
@@ -22,6 +22,8 @@ interface UseLeaderboardResult {
   data: PlayerStats[];
   loading: boolean;
   error: string | null;
+  /** Unix-seconds timestamp of the last *successful* refresh, or null before the first one. */
+  lastUpdated: number | null;
   refetch: () => void;
 }
 
@@ -107,6 +109,7 @@ export function useLeaderboard(
   const [data, setData] = useState<PlayerStats[]>([]);
   const [loading, setLoading] = useState(!seeded.current);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const mountedRef = useRef(true);
   const initialLoadDone = useRef(false);
 
@@ -153,6 +156,7 @@ export function useLeaderboard(
       // Persist assembled leaderboard for instant stale-seed next time
       cache.set(LB_CACHE_KEY, players, 60_000);
       setAllPlayers(players);
+      setLastUpdated(Math.floor(Date.now() / 1000));
     } catch (err) {
       if (!mountedRef.current) return;
       setError(
@@ -189,5 +193,5 @@ export function useLeaderboard(
     fetchData();
   }, [fetchData]);
 
-  return { data, loading, error, refetch };
+  return { data, loading, error, lastUpdated, refetch };
 }

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -19,6 +19,19 @@ function isKnownEventType(s: string): s is ContractEventType {
   return (EVENT_TYPES as readonly string[]).includes(s);
 }
 
+/**
+ * Normalize a Soroban `ledgerClosedAt` value (ISO string from RPC) to Unix
+ * seconds. This is the single place the event pipeline crosses the
+ * "onchain time" boundary, so every `MarketEvent.timestamp` downstream is
+ * guaranteed to be Unix seconds — matching every other timestamp in the app
+ * (market close time, bet time, etc).
+ */
+export function ledgerClosedAtToUnixSeconds(
+  ledgerClosedAt: string | number | Date
+): number {
+  return Math.floor(new Date(ledgerClosedAt).getTime() / 1000);
+}
+
 // ── Parse a single event response into MarketEvent ────────────────────────────
 
 function parseEventResponse(
@@ -32,7 +45,7 @@ function parseEventResponse(
     if (!isKnownEventType(eventName)) return null;
 
     const data = scValToNative(event.value);
-    const timestamp = new Date(event.ledgerClosedAt).getTime();
+    const timestamp = ledgerClosedAtToUnixSeconds(event.ledgerClosedAt);
 
     switch (eventName) {
       case "bet_placed":

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -75,16 +75,55 @@ export function timeUntil(timestamp: number): string {
 }
 
 /**
- * Format a Unix timestamp to a locale-aware date string.
+ * Below this magnitude a timestamp is Unix seconds; at or above it, it's
+ * already in milliseconds. (100_000_000_000 seconds is year ~5138, so any
+ * real-world timestamp cleanly falls on one side of this line.) This makes
+ * every formatter below tolerant of a caller accidentally passing either
+ * unit, which is what caused the leaderboard/activity feed to show
+ * far-future dates when a millisecond value was multiplied by 1000 again.
  */
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
+const MS_THRESHOLD = 100_000_000_000;
+
+function toDate(timestamp: number): Date {
+  const ms = Math.abs(timestamp) < MS_THRESHOLD ? timestamp * 1000 : timestamp;
+  return new Date(ms);
+}
+
+
+export function formatDate(
+  timestamp: number,
+  locale?: string,
+  timeZone?: string
+): string {
+  const date = toDate(timestamp);
+  if (Number.isNaN(date.getTime())) return "Invalid date";
+
+  return new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-  });
+    timeZoneName: "short",
+    ...(timeZone ? { timeZone } : {}),
+  }).format(date);
+}
+
+
+export function formatTime(
+  timestamp: number,
+  locale?: string,
+  timeZone?: string
+): string {
+  const date = toDate(timestamp);
+  if (Number.isNaN(date.getTime())) return "Invalid date";
+
+  return new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+    ...(timeZone ? { timeZone } : {}),
+  }).format(date);
 }
 
 /**


### PR DESCRIPTION
### Summary

This PR fixes the timestamp inconsistencies across the app by standardizing timestamps at the Soroban boundary instead of letting milliseconds leak through the event pipeline. It also makes the date formatting helpers more resilient by handling both Unix seconds and milliseconds, while respecting the user's locale and timezone.

While working on this, I also fixed a couple of unrelated issues that were blocking local development: the missing `frontend/package.json` (which prevented npm install on a fresh clone) and the incomplete Poppins font configuration that caused next `dev/tsc` to fail.

### Root cause

The main issue came from a mismatch in timestamp units.

`services/events.ts` was storing ledgerClosedAt as milliseconds using new `Date(event.ledgerClosedAt).getTime()`, but the market activity page expected timestamps in Unix seconds and multiplied them by 1000 again before creating a Date. That extra conversion pushed timestamps far into the future.

On top of that, the date formatting helpers were hardcoded to en-US without any timezone information, so even valid timestamps could appear inconsistent depending on who was viewing them.

### What I Changed

- Standardized `MarketEvent.timestamp `to Unix seconds by introducing `ledgerClosedAtToUnixSeconds()` in `services/events.ts.`
- Updated formatDate and formatTime to:

- > accept either seconds or milliseconds,
- > use the viewer's locale and timezone by default,
- > include a short timezone label to avoid ambiguity.

-  Fixed the market activity feed to use` formatTime(evt.timestamp) `instead of manually creating a Date from an already-converted timestamp.
- 
-  Added a Last updated timestamp to the leaderboard that only updates after a successful refresh, so failed polls don't show a misleading fresh timestamp.
- Added the missing `frontend/package.json,` reconstructed from the committed `package-lock.json.`
- Fixed the Poppins font configuration in `app/layout.tsx` by adding the required weight array.


### Validation

npx tsc --noEmit passes.
npx vitest run: 163/164 tests passing.
The remaining failing test is unrelated to this PR (Navbar brand text assertion expects StellarPulse but the app renders Stellar Pulse).

I also added tests covering:

timestamp normalization (seconds vs. milliseconds),
locale/timezone formatting,
the ledgerClosedAtToUnixSeconds() conversion,
and the leaderboard logic to ensure lastUpdated isn't updated after a failed refresh.

**Note**
I wasn't able to validate against a live Soroban RPC endpoint in my environment ,  worth a quick manual check against testnet/mainnet before merging.
Closes #27