### PR TITLE
fix: normalize leaderboard timestamp display

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "stellarpulse-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@creit.tech/stellar-wallets-kit": "^1.2.0",
+    "@stellar/stellar-sdk": "^14.5.0",
+    "buffer": "^6.0.3",
+    "next": "^14.2.29",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@types/node": "^22.13.5",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.1",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/frontend/src/__tests__/components/LeaderboardTable.test.tsx
+++ b/frontend/src/__tests__/components/LeaderboardTable.test.tsx
@@ -126,4 +126,9 @@ describe("LeaderboardTable", () => {
     render(<LeaderboardTable players={[]} />);
     expect(screen.getByText("#")).toBeInTheDocument(); // header still renders
   });
+
+  it("renders the leaderboard refresh timestamp", () => {
+    render(<LeaderboardTable players={mockPlayers} lastUpdatedAt={1772111100} />);
+    expect(screen.getByText(/Last updated/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/__tests__/components/Navbar.test.tsx
+++ b/frontend/src/__tests__/components/Navbar.test.tsx
@@ -70,7 +70,7 @@ describe("Navbar", () => {
 
   it("renders the logo / brand name", () => {
     render(<Navbar />);
-    expect(screen.getByText(/StellarPulse/i)).toBeInTheDocument();
+    expect(screen.getByText(/Stellar Pulse/i)).toBeInTheDocument();
   });
 
   it("renders all navigation links", () => {
@@ -87,7 +87,7 @@ describe("Navbar", () => {
 
   it("logo links to home page", () => {
     render(<Navbar />);
-    const logo = screen.getByText(/StellarPulse/i);
+    const logo = screen.getByText(/Stellar Pulse/i);
     expect(logo.closest("a")).toHaveAttribute("href", "/");
   });
 

--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   truncateAddress,
   isValidAmount,
   timeUntil,
+  formatDate,
   calculatePayout,
   calculateOdds,
   bpsToPercent,
@@ -172,6 +173,20 @@ describe("timeUntil", () => {
 });
 
 // ── calculatePayout ───────────────────────────────────────────────────────────
+
+describe("formatDate", () => {
+  it("formats timestamps with a locale, time, and timezone", () => {
+    expect(
+      formatDate(1772111100, { locale: "en-US", timeZone: "UTC" })
+    ).toBe("Feb 26, 2026, 1:05 PM UTC");
+  });
+
+  it("uses the requested locale when formatting", () => {
+    expect(
+      formatDate(1772111100, { locale: "en-GB", timeZone: "UTC" })
+    ).toBe("26 Feb 2026, 13:05 UTC");
+  });
+});
 
 describe("calculatePayout", () => {
   it("calculates correct payout for sole winner (100% of winning side)", () => {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -13,6 +13,7 @@ const inter = Inter({
 
 const poppins = Poppins({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
   variable: "--font-heading",
   display: "swap",
 });

--- a/frontend/src/app/leaderboard/page.tsx
+++ b/frontend/src/app/leaderboard/page.tsx
@@ -12,7 +12,7 @@ import { FiAward } from "react-icons/fi";
 
 export default function LeaderboardPage() {
   const [tab, setTab] = useState<LeaderboardTab>("top_predictors");
-  const { data: players, loading, error } = useLeaderboard(tab);
+  const { data: players, loading, error, lastUpdatedAt } = useLeaderboard(tab);
   const { publicKey } = useWallet();
 
   return (
@@ -70,6 +70,7 @@ export default function LeaderboardPage() {
             <LeaderboardTable
               players={players}
               currentUser={publicKey ?? undefined}
+              lastUpdatedAt={lastUpdatedAt ?? undefined}
             />
           </div>
         )}

--- a/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -2,15 +2,18 @@ import React from "react";
 import type { PlayerStats } from "@/types";
 import PlayerRow from "./PlayerRow";
 import { FiUser } from "react-icons/fi";
+import { formatDate } from "@/utils/helpers";
 
 interface LeaderboardTableProps {
   players: PlayerStats[];
   currentUser?: string;
+  lastUpdatedAt?: number;
 }
 
 export default function LeaderboardTable({
   players,
   currentUser,
+  lastUpdatedAt,
 }: LeaderboardTableProps) {
   const currentUserPlayer = currentUser
     ? players.find((p) => p.address === currentUser)
@@ -41,6 +44,12 @@ export default function LeaderboardTable({
               </p>
             </div>
           </div>
+        </div>
+      )}
+
+      {lastUpdatedAt && (
+        <div className="mb-3 text-right text-xs text-slate-500">
+          Last updated {formatDate(lastUpdatedAt)}
         </div>
       )}
 

--- a/frontend/src/hooks/useLeaderboard.ts
+++ b/frontend/src/hooks/useLeaderboard.ts
@@ -22,6 +22,7 @@ interface UseLeaderboardResult {
   data: PlayerStats[];
   loading: boolean;
   error: string | null;
+  lastUpdatedAt: number | null;
   refetch: () => void;
 }
 
@@ -107,6 +108,7 @@ export function useLeaderboard(
   const [data, setData] = useState<PlayerStats[]>([]);
   const [loading, setLoading] = useState(!seeded.current);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
   const mountedRef = useRef(true);
   const initialLoadDone = useRef(false);
 
@@ -153,6 +155,7 @@ export function useLeaderboard(
       // Persist assembled leaderboard for instant stale-seed next time
       cache.set(LB_CACHE_KEY, players, 60_000);
       setAllPlayers(players);
+      setLastUpdatedAt(Math.floor(Date.now() / 1000));
     } catch (err) {
       if (!mountedRef.current) return;
       setError(
@@ -189,5 +192,5 @@ export function useLeaderboard(
     fetchData();
   }, [fetchData]);
 
-  return { data, loading, error, refetch };
+  return { data, loading, error, lastUpdatedAt, refetch };
 }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -74,17 +74,27 @@ export function timeUntil(timestamp: number): string {
   return `${seconds}s`;
 }
 
+interface FormatDateOptions {
+  locale?: string;
+  timeZone?: string;
+}
+
 /**
- * Format a Unix timestamp to a locale-aware date string.
+ * Format a Unix timestamp to a locale-aware date/time string.
  */
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
+export function formatDate(
+  timestamp: number,
+  options: FormatDateOptions = {}
+): string {
+  return new Intl.DateTimeFormat(options.locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
-    hour: "2-digit",
+    hour: "numeric",
     minute: "2-digit",
-  });
+    timeZone: options.timeZone,
+    timeZoneName: "short",
+  }).format(new Date(timestamp * 1000));
 }
 
 /**


### PR DESCRIPTION
### Description
Fixes #27 by adding a consistent, locale-aware leaderboard refresh timestamp.

### Changes
- Adds a shared `formatDate` helper that respects user locale and includes timezone.
- Tracks the leaderboard refresh time in `useLeaderboard`.
- Displays `Last updated ...` above the leaderboard table.
- Restores the missing frontend `package.json` so npm validation can run.
- Fixes stale frontend test/build issues discovered during validation.

### Validation
- `npm.cmd test` - 156 passed
- `npm.cmd run typecheck` - passed
- `npm.cmd run build` - passed