### PR TITLE
fix: normalize timestamps to user locale in leaderboard views

### DIFF
--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -78,7 +78,7 @@ export function timeUntil(timestamp: number): string {
  * Format a Unix timestamp to a locale-aware date string.
  */
 export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
+  return new Date(timestamp * 1000).toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",


### PR DESCRIPTION
Replace hardcoded 'en-US' locale with browser default (undefined) so timestamps respect the user's local timezone and formatting.

Fixes #27