### PR TITLE
fix: normalize leaderboard and activity timestamps

### DIFF
--- a/frontend/src/__tests__/events.test.ts
+++ b/frontend/src/__tests__/events.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getLatestLedger: vi.fn(),
+  getEvents: vi.fn(),
+}));
+
+vi.mock("@stellar/stellar-sdk", async () => {
+  const actual = await vi.importActual<typeof import("@stellar/stellar-sdk")>(
+    "@stellar/stellar-sdk"
+  );
+  return { ...actual, scValToNative: (value: unknown) => value };
+});
+
+vi.mock("@/services/soroban", () => ({
+  getSorobanServer: () => ({
+    getLatestLedger: mocks.getLatestLedger,
+    getEvents: mocks.getEvents,
+  }),
+}));
+
+import {
+  ledgerClosedAtToUnixSeconds,
+  pollMarketEvents,
+} from "@/services/events";
+
+describe("ledgerClosedAtToUnixSeconds", () => {
+  const expectedSeconds = Date.UTC(2026, 6, 18, 8, 30) / 1000;
+
+  it.each([
+    ["ISO timestamp", "2026-07-18T08:30:00.000Z"],
+    ["offset timestamp", "2026-07-18T16:30:00+08:00"],
+    ["Date instance", new Date("2026-07-18T08:30:00.000Z")],
+    ["Unix milliseconds", expectedSeconds * 1000],
+    ["Unix seconds", expectedSeconds],
+  ])("normalizes a valid %s", (_label, value) => {
+    expect(ledgerClosedAtToUnixSeconds(value)).toBe(expectedSeconds);
+  });
+
+  it.each([
+    ["blank value", ""],
+    ["invalid string", "not-a-date"],
+    ["impossible calendar date", "2026-02-31T08:30:00Z"],
+    ["timestamp without a time zone", "2026-07-18T08:30:00"],
+    ["NaN", Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY],
+    ["invalid Date", new Date(Number.NaN)],
+  ])("rejects %s", (_label, value) => {
+    expect(() => ledgerClosedAtToUnixSeconds(value)).toThrow(
+      new RangeError("Invalid ledger close timestamp")
+    );
+  });
+});
+
+describe("pollMarketEvents", () => {
+  it("drops an event with a malformed close timestamp", async () => {
+    mocks.getLatestLedger.mockResolvedValue({ sequence: 100 });
+    mocks.getEvents.mockResolvedValue({
+      events: [
+        {
+          topic: ["market_cancelled", 7],
+          value: {},
+          ledgerClosedAt: "not-a-date",
+          txHash: "malformed-event",
+        },
+      ],
+    });
+
+    await expect(pollMarketEvents()).resolves.toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/helpers.test.ts
+++ b/frontend/src/__tests__/helpers.test.ts
@@ -4,6 +4,8 @@ import {
   truncateAddress,
   isValidAmount,
   timeUntil,
+  formatDate,
+  formatTime,
   calculatePayout,
   calculateOdds,
   bpsToPercent,
@@ -168,6 +170,49 @@ describe("timeUntil", () => {
     const now = Math.floor(Date.now() / 1000);
     const future = now + 30;
     expect(timeUntil(future)).toBe("30s");
+  });
+});
+
+// ── timestamp formatting ─────────────────────────────────────────────────────
+
+describe("timestamp formatting", () => {
+  const timestamp = Date.UTC(2026, 6, 18, 8, 30) / 1000;
+
+  it("formats a complete timestamp in the requested locale and time zone", () => {
+    const expected = new Intl.DateTimeFormat("en-GB", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short",
+      timeZone: "Asia/Singapore",
+    }).format(new Date(timestamp * 1000));
+
+    expect(
+      formatDate(timestamp, "en-GB", { timeZone: "Asia/Singapore" })
+    ).toBe(expected);
+  });
+
+  it("uses the requested locale instead of hard-coding en-US", () => {
+    const options = { timeZone: "UTC" };
+
+    expect(formatDate(timestamp, "de-DE", options)).not.toBe(
+      formatDate(timestamp, "en-US", options)
+    );
+  });
+
+  it("uses the same local-time rules for compact activity timestamps", () => {
+    const expected = new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short",
+      timeZone: "America/New_York",
+    }).format(new Date(timestamp * 1000));
+
+    expect(
+      formatTime(timestamp, "en-US", { timeZone: "America/New_York" })
+    ).toBe(expected);
   });
 });
 

--- a/frontend/src/__tests__/leaderboard-page.test.tsx
+++ b/frontend/src/__tests__/leaderboard-page.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  lastUpdated: 1_800_000_000 as number | null,
+  formatDate: vi.fn(() => "localized timestamp"),
+}));
+
+vi.mock("@/hooks/useLeaderboard", () => ({
+  useLeaderboard: () => ({
+    data: [],
+    loading: false,
+    error: null,
+    lastUpdated: mocks.lastUpdated,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useWallet", () => ({
+  useWallet: () => ({ publicKey: null }),
+}));
+
+vi.mock("@/utils/helpers", () => ({
+  formatDate: mocks.formatDate,
+}));
+
+import LeaderboardPage from "@/app/leaderboard/page";
+
+describe("LeaderboardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.lastUpdated = 1_800_000_000;
+  });
+
+  it("formats the last successful leaderboard refresh", () => {
+    render(<LeaderboardPage />);
+
+    expect(screen.getByText("Last updated: localized timestamp")).toBeInTheDocument();
+    expect(mocks.formatDate).toHaveBeenCalledWith(1_800_000_000);
+  });
+
+  it("hides the label before any successful refresh", () => {
+    mocks.lastUpdated = null;
+    render(<LeaderboardPage />);
+
+    expect(screen.queryByText(/^Last updated:/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/useLeaderboard.test.tsx
+++ b/frontend/src/__tests__/useLeaderboard.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  getTopPlayers: vi.fn(),
+  getStats: vi.fn(),
+  getMarkets: vi.fn(),
+  getMarketBettors: vi.fn(),
+  getDisplayName: vi.fn(),
+  cacheSet: vi.fn(),
+}));
+
+vi.mock("@/services/leaderboard", () => ({
+  getTopPlayers: mocks.getTopPlayers,
+  getStats: mocks.getStats,
+}));
+
+vi.mock("@/services/market", () => ({
+  getMarkets: mocks.getMarkets,
+  getMarketBettors: mocks.getMarketBettors,
+}));
+
+vi.mock("@/services/referral", () => ({
+  getDisplayName: mocks.getDisplayName,
+}));
+
+vi.mock("@/services/cache", () => ({
+  getStale: () => null,
+  set: mocks.cacheSet,
+}));
+
+vi.mock("@/hooks/useVisiblePoll", () => ({
+  useVisiblePoll: vi.fn(),
+}));
+
+import { useLeaderboard } from "@/hooks/useLeaderboard";
+
+describe("useLeaderboard lastUpdated", () => {
+  const player = {
+    address: "GALICE",
+    displayName: "Alice",
+    points: 100,
+    totalBets: 4,
+    wonBets: 3,
+    lostBets: 1,
+    winRate: 75,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getMarkets.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records Unix seconds only after a successful refresh", async () => {
+    const refreshedAtMs = 1_800_000_000_123;
+    vi.spyOn(Date, "now").mockReturnValue(refreshedAtMs);
+    mocks.getTopPlayers.mockResolvedValue([player]);
+
+    const { result } = renderHook(() => useLeaderboard("top_predictors"));
+
+    expect(result.current.lastUpdated).toBeNull();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.lastUpdated).toBe(Math.floor(refreshedAtMs / 1000));
+  });
+
+  it("keeps the previous timestamp when services return no refreshed data", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+    mocks.getTopPlayers.mockResolvedValueOnce([player]);
+
+    const { result } = renderHook(() => useLeaderboard("top_predictors"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const successfulRefresh = result.current.lastUpdated;
+    expect(successfulRefresh).not.toBeNull();
+
+    now.mockReturnValue(1_900_000_000_000);
+    let resolveRefresh!: (players: never[]) => void;
+    const emptyRefresh = new Promise<never[]>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    mocks.getTopPlayers.mockReturnValueOnce(emptyRefresh);
+
+    act(() => result.current.refetch());
+    await act(async () => {
+      resolveRefresh([]);
+      await emptyRefresh;
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.lastUpdated).toBe(successfulRefresh);
+  });
+});

--- a/frontend/src/app/leaderboard/page.tsx
+++ b/frontend/src/app/leaderboard/page.tsx
@@ -8,11 +8,12 @@ import LeaderboardTable from "@/components/leaderboard/LeaderboardTable";
 import Skeleton from "@/components/ui/Skeleton";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorBoundary from "@/components/ui/ErrorBoundary";
+import { formatDate } from "@/utils/helpers";
 import { FiAward } from "react-icons/fi";
 
 export default function LeaderboardPage() {
   const [tab, setTab] = useState<LeaderboardTab>("top_predictors");
-  const { data: players, loading, error } = useLeaderboard(tab);
+  const { data: players, loading, error, lastUpdated } = useLeaderboard(tab);
   const { publicKey } = useWallet();
 
   return (
@@ -31,6 +32,11 @@ export default function LeaderboardPage() {
         <p className="text-slate-400">
           Rankings update in real-time from onchain data.
         </p>
+        {lastUpdated !== null && (
+          <p className="mt-1 text-xs text-slate-500">
+            Last updated: {formatDate(lastUpdated)}
+          </p>
+        )}
       </div>
 
       {/* Tabs */}

--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -7,7 +7,13 @@ import { useWallet } from "@/hooks/useWallet";
 import { useToken } from "@/hooks/useToken";
 import { pollMarketEvents } from "@/services/events";
 import { getXlmBalance } from "@/services/soroban";
-import { displayXLM, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
+import {
+  displayXLM,
+  formatXLM,
+  formatTime,
+  calculatePayout,
+  truncateAddress,
+} from "@/utils/helpers";
 import {
   WIN_POINTS,
   LOSE_POINTS,
@@ -319,7 +325,7 @@ export default function MarketDetailPage({
                       </span>
                     </div>
                     <span className="text-xs text-slate-600 shrink-0">
-                      {new Date(evt.timestamp * 1000).toLocaleTimeString()}
+                      {formatTime(evt.timestamp)}
                     </span>
                   </div>
                 ))}

--- a/frontend/src/hooks/useLeaderboard.ts
+++ b/frontend/src/hooks/useLeaderboard.ts
@@ -22,6 +22,7 @@ interface UseLeaderboardResult {
   data: PlayerStats[];
   loading: boolean;
   error: string | null;
+  lastUpdated: number | null;
   refetch: () => void;
 }
 
@@ -107,6 +108,7 @@ export function useLeaderboard(
   const [data, setData] = useState<PlayerStats[]>([]);
   const [loading, setLoading] = useState(!seeded.current);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const mountedRef = useRef(true);
   const initialLoadDone = useRef(false);
 
@@ -153,6 +155,9 @@ export function useLeaderboard(
       // Persist assembled leaderboard for instant stale-seed next time
       cache.set(LB_CACHE_KEY, players, 60_000);
       setAllPlayers(players);
+      if (players.length > 0) {
+        setLastUpdated(Math.floor(Date.now() / 1000));
+      }
     } catch (err) {
       if (!mountedRef.current) return;
       setError(
@@ -189,5 +194,5 @@ export function useLeaderboard(
     fetchData();
   }, [fetchData]);
 
-  return { data, loading, error, refetch };
+  return { data, loading, error, lastUpdated, refetch };
 }

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -19,6 +19,78 @@ function isKnownEventType(s: string): s is ContractEventType {
   return (EVENT_TYPES as readonly string[]).includes(s);
 }
 
+const MILLISECOND_TIMESTAMP_THRESHOLD = 100_000_000_000;
+const ISO_TIMESTAMP_WITH_TIME_ZONE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:[zZ]|[+-](\d{2}):(\d{2}))$/;
+
+/** Normalize an RPC ledger close time to the app's Unix-seconds contract. */
+export function ledgerClosedAtToUnixSeconds(
+  ledgerClosedAt: string | number | Date
+): number {
+  let timestampSeconds: number;
+
+  if (typeof ledgerClosedAt === "number") {
+    timestampSeconds =
+      Math.abs(ledgerClosedAt) >= MILLISECOND_TIMESTAMP_THRESHOLD
+        ? ledgerClosedAt / 1000
+        : ledgerClosedAt;
+  } else if (ledgerClosedAt instanceof Date) {
+    timestampSeconds = ledgerClosedAt.getTime() / 1000;
+  } else {
+    const timestampText = ledgerClosedAt.trim();
+    const match = ISO_TIMESTAMP_WITH_TIME_ZONE.exec(timestampText);
+    if (!match) throw new RangeError("Invalid ledger close timestamp");
+
+    const [, yearText, monthText, dayText, hourText, minuteText, secondText] =
+      match;
+    const year = Number(yearText);
+    const month = Number(monthText);
+    const day = Number(dayText);
+    const hour = Number(hourText);
+    const minute = Number(minuteText);
+    const second = Number(secondText);
+    const offsetHour = Number(match[7] ?? 0);
+    const offsetMinute = Number(match[8] ?? 0);
+    const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+    const daysInMonth = [
+      31,
+      leapYear ? 29 : 28,
+      31,
+      30,
+      31,
+      30,
+      31,
+      31,
+      30,
+      31,
+      30,
+      31,
+    ];
+
+    if (
+      month < 1 ||
+      month > 12 ||
+      day < 1 ||
+      day > daysInMonth[month - 1] ||
+      hour > 23 ||
+      minute > 59 ||
+      second > 59 ||
+      offsetHour > 23 ||
+      offsetMinute > 59
+    ) {
+      throw new RangeError("Invalid ledger close timestamp");
+    }
+
+    timestampSeconds = Date.parse(timestampText) / 1000;
+  }
+
+  if (!Number.isFinite(timestampSeconds)) {
+    throw new RangeError("Invalid ledger close timestamp");
+  }
+
+  return Math.floor(timestampSeconds);
+}
+
 // ── Parse a single event response into MarketEvent ────────────────────────────
 
 function parseEventResponse(
@@ -32,7 +104,7 @@ function parseEventResponse(
     if (!isKnownEventType(eventName)) return null;
 
     const data = scValToNative(event.value);
-    const timestamp = new Date(event.ledgerClosedAt).getTime();
+    const timestamp = ledgerClosedAtToUnixSeconds(event.ledgerClosedAt);
 
     switch (eventName) {
       case "bet_placed":

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -74,17 +74,43 @@ export function timeUntil(timestamp: number): string {
   return `${seconds}s`;
 }
 
-/**
- * Format a Unix timestamp to a locale-aware date string.
- */
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZoneName: "short",
+};
+
+const TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZoneName: "short",
+};
+
+/** Format a Unix-seconds timestamp in the user's locale and time zone. */
+export function formatDate(
+  timestamp: number,
+  locale?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...DATE_TIME_OPTIONS,
+    ...options,
+  }).format(new Date(timestamp * 1000));
+}
+
+/** Format a Unix-seconds timestamp for compact activity displays. */
+export function formatTime(
+  timestamp: number,
+  locale?: Intl.LocalesArgument,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...TIME_OPTIONS,
+    ...options,
+  }).format(new Date(timestamp * 1000));
 }
 
 /**


### PR DESCRIPTION
/claim #27

## Summary
- Normalize Soroban ledger-close values once to the app's Unix-seconds contract, covering ISO strings, Date values, Unix seconds, and Unix milliseconds.
- Reject malformed or timezone-ambiguous values before they enter UI state.
- Format leaderboard and market activity timestamps with shared viewer-locale/time-zone formatters.
- Show the leaderboard's last-updated time only after refreshed data is available.

## Correctness coverage
- Fixes the existing milliseconds/seconds mismatch at the event boundary.
- Handles numeric seconds and milliseconds without double conversion.
- Validates explicit time zones and impossible calendar dates.
- Keeps the patch scoped to timestamp behavior, with no package, font, or navbar changes.

## Verification
- All relevant non-Navbar suites: 166/166 passing.
- Focused timestamp, event, hook, and page suites: 69/69 passing.
- `git diff --check`: clean.
- The isolated upstream Navbar suite remains 5/7 because two unchanged assertions expect `StellarPulse` while the existing component renders `Stellar Pulse`.
- `npx tsc --noEmit` reaches only the pre-existing missing Poppins `weight` in untouched `src/app/layout.tsx`.

Closes #27