### PR TITLE
fix: normalize timestamps to user locale with consistent formatting (fixes #27)

### DIFF
--- a/frontend/src/app/markets/[id]/page.tsx
+++ b/frontend/src/app/markets/[id]/page.tsx
@@ -7,7 +7,7 @@ import { useWallet } from "@/hooks/useWallet";
 import { useToken } from "@/hooks/useToken";
 import { pollMarketEvents } from "@/services/events";
 import { getXlmBalance } from "@/services/soroban";
-import { displayXLM, formatXLM, calculatePayout, truncateAddress } from "@/utils/helpers";
+import { displayXLM, formatXLM, calculatePayout, truncateAddress, formatDate } from "@/utils/helpers";
 import {
   WIN_POINTS,
   LOSE_POINTS,
@@ -319,7 +319,7 @@ export default function MarketDetailPage({
                       </span>
                     </div>
                     <span className="text-xs text-slate-600 shrink-0">
-                      {new Date(evt.timestamp * 1000).toLocaleTimeString()}
+                      {formatDate(evt.timestamp)}
                     </span>
                   </div>
                 ))}

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -78,7 +78,7 @@ export function timeUntil(timestamp: number): string {
  * Format a Unix timestamp to a locale-aware date string.
  */
 export function formatDate(timestamp: number): string {
-  return new Date(timestamp * 1000).toLocaleDateString("en-US", {
+  return new Date(timestamp * 1000).toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",


### PR DESCRIPTION
## Summary

Fixes #27 — timezone display inconsistency.

## Changes

1. **helpers.ts**: Changed `formatDate()` from hardcoded `en-US` locale to `undefined`, so the browser uses the viewer's locale and timezone automatically
2. **page.tsx**: Replaced raw `toLocaleTimeString()` with `formatDate()` so event timestamps show both date + time with proper locale

## Before
- Event timestamps showed only time (e.g., "3:45 PM") with no date context
- Non-US users saw dates in en-US format regardless of their locale

## After
- Event timestamps show formatted date + time (e.g., "Jul 19, 2026, 3:45 PM") in the viewer's locale

Closes #27