### PR TITLE
fix(market): robust MarketImage placeholder with no console errors on missing image

### DIFF
--- a/frontend/src/__tests__/components/MarketImage.test.tsx
+++ b/frontend/src/__tests__/components/MarketImage.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// next/image renders a plain <img> in tests, forwarding only DOM-safe props so
+// no React "unknown attribute" warnings leak into the console assertions below.
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    className,
+    onError,
+  }: {
+    src: string;
+    alt: string;
+    className?: string;
+    onError?: () => void;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} className={className} onError={onError} />
+  ),
+}));
+
+import MarketImage from "@/components/market/MarketImage";
+
+describe("MarketImage", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the labelled placeholder when no src is provided", () => {
+    render(<MarketImage alt="Market question" />);
+
+    const placeholder = screen.getByRole("img", { name: "Market question" });
+    expect(placeholder).toBeInTheDocument();
+    // No real <img> element should be mounted for a missing image
+    expect(document.querySelector("img")).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([["  "], [""], ["not-a-url"], ["data:image/png;base64,xxx"]])(
+    "shows the placeholder (no console errors) for the unusable src %j",
+    (src) => {
+      render(<MarketImage src={src} alt="Broken" />);
+
+      expect(screen.getByRole("img", { name: "Broken" })).toBeInTheDocument();
+      expect(document.querySelector("img")).toBeNull();
+      expect(errorSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  it("renders a real image for a valid https src", () => {
+    render(
+      <MarketImage src="https://cdn.example.com/market.png" alt="Live market" />
+    );
+
+    const img = screen.getByRole("img", { name: "Live market" });
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", "https://cdn.example.com/market.png");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders a real image for a root-relative src", () => {
+    render(<MarketImage src="/uploads/market.png" alt="Local market" />);
+
+    const img = screen.getByRole("img", { name: "Local market" });
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", "/uploads/market.png");
+  });
+
+  it("falls back to the placeholder when the image fails to load", () => {
+    render(
+      <MarketImage src="https://cdn.example.com/missing.png" alt="Gone" />
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "Gone" }));
+
+    // After onError the <img> is unmounted and the placeholder div is shown
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByRole("img", { name: "Gone" })).toBeInTheDocument();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("recovers when the src changes after a previous failure (no stale placeholder)", () => {
+    const { rerender } = render(
+      <MarketImage src="https://cdn.example.com/broken.png" alt="Market" />
+    );
+
+    // Break the first image -> placeholder
+    fireEvent.error(screen.getByRole("img", { name: "Market" }));
+    expect(document.querySelector("img")).toBeNull();
+
+    // A new, valid src on the same instance must show an image again
+    rerender(
+      <MarketImage src="https://cdn.example.com/fresh.png" alt="Market" />
+    );
+
+    const img = screen.getByRole("img", { name: "Market" });
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", "https://cdn.example.com/fresh.png");
+  });
+});

--- a/frontend/src/components/market/MarketImage.tsx
+++ b/frontend/src/components/market/MarketImage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
 
 interface MarketImageProps {
@@ -10,28 +10,52 @@ interface MarketImageProps {
   rounded?: "top" | "all";
 }
 
+/**
+ * Only absolute http(s) URLs and root-relative paths are safe to hand to
+ * next/image. Anything else (empty string, whitespace, data:/blob: URIs, or a
+ * bare non-URL string) makes next/image emit a runtime console error, so we
+ * treat those as "no image" and fall back to the placeholder instead.
+ */
+function isRenderableSrc(src?: string): src is string {
+  if (!src) return false;
+  const trimmed = src.trim();
+  if (!trimmed) return false;
+  return (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("https://")
+  );
+}
+
 export default function MarketImage({
   src,
   alt,
   className = "",
   rounded = "all",
 }: MarketImageProps) {
-  const initialSrc = src?.trim() ? src : "";
-  const [imgSrc, setImgSrc] = useState(initialSrc);
+  const canRender = isRenderableSrc(src);
   const [failed, setFailed] = useState(false);
 
-  const roundedClass =
-    rounded === "top" ? "rounded-t-2xl" : "rounded-xl";
+  // Reset the failed flag whenever the source changes, so a component instance
+  // that gets reused for a different market (e.g. a recycled list row) does not
+  // keep showing a stale placeholder from a previously broken image.
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
 
-  const showImage = Boolean(imgSrc) && !failed;
+  const roundedClass = rounded === "top" ? "rounded-t-2xl" : "rounded-xl";
+  const showImage = canRender && !failed;
 
   if (!showImage) {
     return (
       <div
+        role="img"
+        aria-label={alt}
         className={`relative w-full aspect-video overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 flex items-center justify-center ${roundedClass} ${className}`}
       >
         <div className="text-center opacity-60">
           <svg
+            aria-hidden="true"
             className="w-12 h-12 mx-auto mb-2 text-slate-600"
             fill="none"
             viewBox="0 0 24 24"
@@ -55,7 +79,7 @@ export default function MarketImage({
       className={`relative w-full aspect-video overflow-hidden bg-surface-hover ${roundedClass} ${className}`}
     >
       <Image
-        src={imgSrc}
+        src={src as string}
         alt={alt}
         fill
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"


### PR DESCRIPTION
Closes #16

Improves the market image placeholder so it renders correctly and never triggers console errors when an image is missing or broken (the two acceptance criteria).

What changed in `MarketImage`:
- Validates the src before handing it to next/image. Only absolute http(s) URLs and root-relative paths are rendered; empty strings, whitespace, data:/blob: URIs and other bare non-URL values now fall straight to the placeholder instead of reaching next/image and emitting a runtime console error.
- - Resets the internal `failed` flag when the `src` prop changes (via useEffect), so a component instance reused for a different market (e.g. a recycled list row) no longer keeps showing a stale placeholder from a previously broken image.
- - Removes the dead `imgSrc` state that was initialised once and never updated.
- - Accessibility: the placeholder now exposes `role="img"` + `aria-label={alt}`, and the decorative SVG is marked `aria-hidden`, so a missing image is still announced by its question text.
Tests (`MarketImage.test.tsx`, 9 cases): placeholder renders for missing/empty/invalid/data-URI src with no console.error or console.warn; a real image renders for valid https and root-relative src; onError falls back to the placeholder; and a changed src recovers after a previous failure (no stale placeholder). next/image is mocked to a plain img, matching the existing MarketCard test.

Verified locally: `npx vitest run src/__tests__/components/MarketImage.test.tsx` -> 9 passed. Note: the rest of the component suite currently fails on main due to a pre-existing syntax error in `frontend/src/utils/helpers.ts` (leftover from the conflicting timezone merges); this file does not import helpers.ts, so it runs green regardless.