### PR TITLE
fix(leaderboard): add locale-aware timestamp normalization and unit tests (#80)

### DIFF
--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,12 @@
+import { formatLeaderboardTimestamp } from './date';
+
+describe('Leaderboard Timestamp Utilities', () => {
+  it('should return empty string for empty input', () => {
+    expect(formatLeaderboardTimestamp('')).toBe('');
+  });
+
+  it('should format valid timestamp', () => {
+    const res = formatLeaderboardTimestamp('2026-08-06T12:00:00Z');
+    expect(res).toBeTruthy();
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,13 @@
+export function formatLeaderboardTimestamp(timestamp: string | number | Date): string {
+  if (!timestamp) return '';
+  try {
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) return '';
+    return new Intl.DateTimeFormat(navigator.language || 'en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(date);
+  } catch (err) {
+    return new Date(timestamp).toISOString();
+  }
+}


### PR DESCRIPTION
Resolves #80.
/claim #80

Implements locale-aware timestamp normalization in src/utils/date.ts and dedicated unit test suite in src/utils/date.test.ts.